### PR TITLE
Correct DELE, MKD, and RMD Replies

### DIFF
--- a/source/ftp_cmd.c
+++ b/source/ftp_cmd.c
@@ -66,7 +66,6 @@ void ftp_cmd_LIST(int s, char* cmd, char* arg)
 
 void ftp_cmd_MKD(int s, char* cmd, char* arg)
 {
-	ftp_sendResponse(s, 150, "Creating directory");
 	sprintf(tmpStr, "%s%s", currentPath, arg);
 
 	int ret;
@@ -77,7 +76,6 @@ void ftp_cmd_MKD(int s, char* cmd, char* arg)
 
 void ftp_cmd_RMD(int s, char* cmd, char* arg)
 {
-	ftp_sendResponse(s, 150, "Deleting folder");
 	sprintf(tmpStr, "%s%s", currentPath, arg);
 	
 	int ret;
@@ -88,7 +86,6 @@ void ftp_cmd_RMD(int s, char* cmd, char* arg)
 
 void ftp_cmd_DELE(int s, char* cmd, char* arg)
 {
-	ftp_sendResponse(s, 150, "Deleting file");
 	sprintf(tmpStr, "%s%s", currentPath, arg);
 	
 	int ret;


### PR DESCRIPTION
Per [RFC 959](https://tools.ietf.org/html/rfc959#section-6), response codes beginning with 1 indicating a waiting state do not apply to a majority of FTP commands. This pull request removes those extraneous responses and prevents potentially confusing error messages on FTP clients.
