### PR TITLE
Directory Tree Copy Fix: Automatic Directory Creation on STOR

### DIFF
--- a/source/ftp_cmd.h
+++ b/source/ftp_cmd.h
@@ -1,6 +1,8 @@
 #ifndef FTP_CMD_H
 #define FTP_CMD_H
 
+#define PATH_EXISTS (0xC82044BE)
+
 typedef void (*ftp_cmdhandler)(int s, char* cmd, char* arg);
 typedef struct
 {


### PR DESCRIPTION
Barring exceptions, when `STOR` is used on a working path that does not yet exist, that path should be created.  This small patch fixes copying over directory trees when using clients that use this mechanism.  This branch also adds a "directory-exists" code (a candidate I think for `include/services/fs.h` in `libctru`) for changing behavior slightly for a directory that already exists; this should help with adding error management.
